### PR TITLE
Update package to work with Moleculer 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,28 @@
 [![Downloads](https://img.shields.io/npm/dm/moleculer-sentry.svg)](https://www.npmjs.com/package/moleculer-sentry)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FYourSoftRun%2Fmoleculer-sentry.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FYourSoftRun%2Fmoleculer-sentry?ref=badge_shield)
 
-## How to use it
+## Usage
+
+This package uses Moleculer's tracing function to catch errors and send them to sentry. In oder for it to function
+properly, you need to enable tracing and use the "Event" exporter. To see how to set up tracing, please refer to
+the [moleculer documentation](https://moleculer.services/docs/0.14/tracing.html#Event).
+
 ```js
 const SentryMixin = require('moleculer-sentry')
 
 module.exports = {
   mixins: [SentryMixin],
+
   settings: {
-    /** @type {String} DSN given by sentry. */
-    dsn: null,
-    /** @type {Object?} Additional options for `Sentry.init` */
-    options: {},
-    /** @type {Object?} Options for the sentry scope */
-    scope: {
-      /** @type {String?} Name of the meta containing user infos */
-      user: null
-    }
+    /** @type {Object?} Sentry configuration wrapper. */
+    sentry: {
+      /** @type {String} DSN given by sentry. */
+      dsn: null,
+      /** @type {Object} Additional options for `Sentry.init`. */
+      options: {},
+      /** @type {String?} Name of the meta containing user infos. */
+      userMetaKey: null,
+    },
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ module.exports = {
     sentry: {
       /** @type {String} DSN given by sentry. */
       dsn: null,
+      /** @type {String} Name of event fired by "Event" exported in tracing. */
+      tracingEventName: '$tracing.spans',
       /** @type {Object} Additional options for `Sentry.init`. */
       options: {},
       /** @type {String?} Name of the meta containing user infos. */

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "eslint-plugin-jest": "^22.17.0",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
-    "moleculer": "^0.13.11"
+    "moleculer": "^0.14.19"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@ module.exports = {
   name: 'sentry',
 
   /**
-	 * Default settings
-	 */
+   * Default settings
+   */
   settings: {
     /** @type {String} DSN given by sentry. */
     dsn: null,
@@ -28,8 +28,8 @@ module.exports = {
   },
 
   /**
-	 * Events
-	 */
+   * Events
+   */
   events: {
     'metrics.trace.span.finish'(metric) {
       if (metric.error && this.isSentryReady() && (!this.shouldReport || this.shouldReport(metric) == true)) {
@@ -39,15 +39,15 @@ module.exports = {
   },
 
   /**
-	 * Methods
-	 */
+   * Methods
+   */
   methods: {
     /**
-		 * Get service name from metric event (Imported from moleculer-jaeger)
-		 *
-		 * @param {Object} metric
-		 * @returns {String}
-		 */
+     * Get service name from metric event (Imported from moleculer-jaeger)
+     *
+     * @param {Object} metric
+     * @returns {String}
+     */
     getServiceName(metric) {
       if (!metric.service && metric.action) {
         const parts = metric.action.name.split('.')
@@ -58,22 +58,22 @@ module.exports = {
     },
 
     /**
-		 * Get span name from metric event. By default it returns the action name (Imported from moleculer-jaeger)
-		 *
-		 * @param {Object} metric
-		 * @returns  {String}
-		 */
+     * Get span name from metric event. By default it returns the action name (Imported from moleculer-jaeger)
+     *
+     * @param {Object} metric
+     * @returns  {String}
+     */
     getSpanName(metric) {
       return metric.action ? metric.action.name : metric.name
     },
 
     /**
-		 * Send error to sentry, based on the metric error
-		 *
-		 * @param {Object} metric
-		 */
+     * Send error to sentry, based on the metric error
+     *
+     * @param {Object} metric
+     */
     sendError(metric) {
-      Sentry.withScope(scope => {
+      Sentry.withScope((scope) => {
         scope.setTag('id', metric.requestID)
         scope.setTag('service', this.getServiceName(metric))
         scope.setTag('span', this.getSpanName(metric))
@@ -96,8 +96,8 @@ module.exports = {
     },
 
     /**
-		 * Check if sentry is configured or not
-		 */
+     * Check if sentry is configured or not
+     */
     isSentryReady() {
       return Sentry.getCurrentHub().getClient() !== undefined
     }

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ module.exports = {
     '$tracing.spans'(metrics) {
       metrics.forEach((metric) => {
         if (metric.error && this.isSentryReady() && (!this.shouldReport || this.shouldReport(metric) == true)) {
-          this.sendError(metric)
+          this.sendSentryError(metric)
         }
       })
     }
@@ -114,7 +114,7 @@ module.exports = {
      *
      * @param {Object} metric
      */
-    sendError(metric) {
+    sendSentryError(metric) {
       Sentry.withScope((scope) => {
         scope.setTag('id', metric.requestID)
         scope.setTag('service', this.getServiceName(metric))

--- a/src/index.js
+++ b/src/index.js
@@ -52,10 +52,12 @@ module.exports = {
    * Events
    */
   events: {
-    'metrics.trace.span.finish'(metric) {
-      if (metric.error && this.isSentryReady() && (!this.shouldReport || this.shouldReport(metric) == true)) {
-        this.sendError(metric)
-      }
+    '$tracing.spans'(metrics) {
+      metrics.forEach((metric) => {
+        if (metric.error && this.isSentryReady() && (!this.shouldReport || this.shouldReport(metric) == true)) {
+          this.sendError(metric)
+        }
+      })
     }
   },
 

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -3,7 +3,10 @@ const Sentry = require('@sentry/node')
 const SentryHub = require('@sentry/hub')
 
 const SentryService = require('../../index.js')
-const SentryServiceWithDSN = { ...SentryService, settings: { dsn: 'https://abc:xyz@localhost:1234/123' } }
+const SentryServiceWithDSN = {
+  ...SentryService,
+  settings: { ...SentryService.settings, dsn: 'https://abc:xyz@localhost:1234/123' }
+}
 
 describe('Sentry init', () => {
   it('should not init sentry', async () => {
@@ -67,7 +70,10 @@ describe('Events', () => {
 
 describe('sendError scope', () => {
   const broker = new ServiceBroker({ logger: false })
-  const service = broker.createService({ ...SentryServiceWithDSN, settings: { ...SentryServiceWithDSN.settings, scope: { user: 'user' } } })
+  const service = broker.createService({
+    ...SentryServiceWithDSN,
+    settings: { ...SentryServiceWithDSN.settings, scope: { user: 'user' } }
+  })
 
   beforeAll(() => broker.start())
   afterAll(() => broker.stop())
@@ -108,7 +114,12 @@ describe('sendError scope', () => {
     scope.setUser = jest.fn()
     Sentry.withScope = jest.fn(cb => cb(scope))
     const error = { type: 'test', message: 'test', code: 4224, data: { test: true } }
-    service.sendError({ requestID: 'tracingiddata', error, action: { name: 'testdata' }, meta: { user: { id: 'test', email: 'test@example.com' } } })
+    service.sendError({
+      requestID: 'tracingiddata',
+      error,
+      action: { name: 'testdata' },
+      meta: { user: { id: 'test', email: 'test@example.com' } }
+    })
     expect(scope.setTag).toHaveBeenCalledTimes(5)
     expect(scope.setTag).toHaveBeenCalledWith('id', 'tracingiddata')
     expect(scope.setTag).toHaveBeenCalledWith('span', 'testdata')

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -2,10 +2,13 @@ const { ServiceBroker } = require('moleculer')
 const Sentry = require('@sentry/node')
 const SentryHub = require('@sentry/hub')
 
-const SentryService = require('../../index.js')
+const SentryMixin = require('../../index.js')
+const SentryService = {
+  mixins: [SentryMixin],
+}
 const SentryServiceWithDSN = {
-  ...SentryService,
-  settings: { ...SentryService.settings, sentry: { dsn: 'https://abc:xyz@localhost:1234/123' } }
+  mixins: [SentryMixin],
+  settings: { sentry: { dsn: 'https://abc:xyz@localhost:1234/123' } }
 }
 
 describe('Sentry init', () => {
@@ -71,8 +74,8 @@ describe('Events', () => {
 describe('sendError scope', () => {
   const broker = new ServiceBroker({ logger: false })
   const service = broker.createService({
-    ...SentryServiceWithDSN,
-    settings: { ...SentryServiceWithDSN.settings, sentry: { userMetaKey: 'user' } }
+    mixins: [SentryServiceWithDSN],
+    settings: { sentry: { userMetaKey: 'user' } }
   })
 
   beforeAll(() => broker.start())

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -42,29 +42,29 @@ describe('Events', () => {
   it('should not sendError (no sentry)', () => {
     const oldSentryReady = service.isSentryReady
     service.isSentryReady = jest.fn(() => false)
-    service.sendError = jest.fn()
+    service.sendSentryError = jest.fn()
 
     broker.emit('$tracing.spans', [{ error: {} }])
 
-    expect(service.sendError).not.toHaveBeenCalled()
+    expect(service.sendSentryError).not.toHaveBeenCalled()
     service.isSentryReady = oldSentryReady
   })
 
   it('should not sendError (no error)', () => {
-    service.sendError = jest.fn()
+    service.sendSentryError = jest.fn()
 
     broker.emit('$tracing.spans', [{}])
 
-    expect(service.sendError).not.toHaveBeenCalled()
+    expect(service.sendSentryError).not.toHaveBeenCalled()
   })
 
   it('should sendError', () => {
-    service.sendError = jest.fn()
+    service.sendSentryError = jest.fn()
     const error = { type: 'test', message: 'test' }
 
     broker.emit('$tracing.spans', [{ error }])
 
-    expect(service.sendError).toHaveBeenCalledWith({ error })
+    expect(service.sendSentryError).toHaveBeenCalledWith({ error })
   })
 })
 
@@ -83,7 +83,7 @@ describe('sendError scope', () => {
     scope.setTag = jest.fn()
     Sentry.withScope = jest.fn((cb) => cb(scope))
     const error = { type: 'test', message: 'test', code: 42 }
-    service.sendError({ requestID: 'tracingid', error, service: 'errors', action: { name: 'test' } })
+    service.sendSentryError({ requestID: 'tracingid', error, service: 'errors', action: { name: 'test' } })
     expect(scope.setTag).toHaveBeenCalledTimes(5)
     expect(scope.setTag).toHaveBeenCalledWith('id', 'tracingid')
     expect(scope.setTag).toHaveBeenCalledWith('service', 'errors')
@@ -97,7 +97,7 @@ describe('sendError scope', () => {
     scope.setExtra = jest.fn()
     Sentry.withScope = jest.fn((cb) => cb(scope))
     const error = { type: 'test', message: 'test', code: 4224, data: { test: true } }
-    service.sendError({ requestID: 'tracingiddata', error, action: { name: 'testdata' } })
+    service.sendSentryError({ requestID: 'tracingiddata', error, action: { name: 'testdata' } })
     expect(scope.setTag).toHaveBeenCalledTimes(5)
     expect(scope.setTag).toHaveBeenCalledWith('id', 'tracingiddata')
     expect(scope.setTag).toHaveBeenCalledWith('span', 'testdata')
@@ -114,7 +114,7 @@ describe('sendError scope', () => {
     scope.setUser = jest.fn()
     Sentry.withScope = jest.fn((cb) => cb(scope))
     const error = { type: 'test', message: 'test', code: 4224, data: { test: true } }
-    service.sendError({
+    service.sendSentryError({
       requestID: 'tracingiddata',
       error,
       action: { name: 'testdata' },
@@ -143,12 +143,12 @@ describe('sendError captureMessage', () => {
   it('should capture basic message', () => {
     Sentry.captureEvent = jest.fn()
     let error = { type: 'test', message: 'test', code: 42, stack: 'stack' }
-    service.sendError({ requestID: 'tracingid', error, service: { name: 'errors' }, name: 'test' })
+    service.sendSentryError({ requestID: 'tracingid', error, service: { name: 'errors' }, name: 'test' })
     expect(Sentry.captureEvent).toHaveBeenCalledTimes(1)
     expect(Sentry.captureEvent).toHaveBeenCalledWith({ message: 'test', stacktrace: ['stack'] })
     Sentry.captureEvent.mockReset()
     error = { type: 'test', message: 'test', code: 42, stack: ['stack'] }
-    service.sendError({ requestID: 'tracingid', error, service: { name: 'errors' }, name: 'test' })
+    service.sendSentryError({ requestID: 'tracingid', error, service: { name: 'errors' }, name: 'test' })
     expect(Sentry.captureEvent).toHaveBeenCalledTimes(1)
     expect(Sentry.captureEvent).toHaveBeenCalledWith({ message: 'test', stacktrace: ['stack'] })
   })
@@ -170,17 +170,17 @@ describe('sendError with shouldReport', () => {
   afterAll(() => broker.stop())
 
   it('should report error', () => {
-    service.sendError = jest.fn()
+    service.sendSentryError = jest.fn()
     const error = { type: 'test', message: 'test', code: 42, stack: 'stack' }
     broker.emit('$tracing.spans', [{ error }])
-    expect(service.sendError).toHaveBeenCalledTimes(1)
+    expect(service.sendSentryError).toHaveBeenCalledTimes(1)
   })
 
   it('should not report error', () => {
-    service.sendError = jest.fn()
+    service.sendSentryError = jest.fn()
     const error = { type: 'test', message: 'test', code: 24, stack: 'stack' }
     broker.emit('$tracing.spans', [{ error }])
-    expect(service.sendError).not.toHaveBeenCalledTimes(1)
+    expect(service.sendSentryError).not.toHaveBeenCalledTimes(1)
   })
 
 })


### PR DESCRIPTION
Heya!

I've taken some time and updated the package.

Changes:
1. updated the package to use "Event" exporter instead of "EventLegacy"
2. added the option to change `trackingEventName`, so if you're default naming differs from documentation, you can still use the package
3. changed the default `sendError` function name to `sendSentryError` so it won't collide with error reporter from api-gateway module
4. moved default variables configuration under the `sentry` key in settings as to not collide with any custom ones you create
5. deprecated old settings not to break old installations

Please review it <3

